### PR TITLE
Typo seperation >> separation

### DIFF
--- a/src/main/resources/fxml/userinterface.fxml
+++ b/src/main/resources/fxml/userinterface.fxml
@@ -159,7 +159,7 @@
                                                   <ChoiceBox fx:id="choiceBoxPFM" prefHeight="25.0" prefWidth="246.0" />
                                              </graphic></Label>
                                           <Separator layoutX="-6.0" layoutY="42.0" prefHeight="3.0" prefWidth="412.0" />
-                                          <Label contentDisplay="RIGHT" graphicTextGap="8.0" layoutX="16.0" layoutY="351.0" text="Colour Seperation:">
+                                          <Label contentDisplay="RIGHT" graphicTextGap="8.0" layoutX="16.0" layoutY="351.0" text="Colour Separation:">
                                              <graphic>
                                                 <ChoiceBox fx:id="choiceBoxColourSeperation" prefHeight="25.0" prefWidth="265.0" />
                                              </graphic>


### PR DESCRIPTION
The typo is also in `choiceBoxColourSeperation` but I don't know in which other files this value is used so I decided to leave it the way it is as it's not something the end user sees.
(I'm using Github in my browser and don't know how to do a search for a string in all files this way).