### PR TITLE
Update README.md to include requirements for a Raspberry PI ARM32 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ You can choose from the following options.
 
    Includes all required libraries but you must manually install [JAVA 11+](https://www.oracle.com/java/technologies/javase-downloads.html)
 
+4) **Raspberry PI (ARM32) - Executable** _(.jar)_ 
+
+   As JavaFX is no longer part of the JDK (since JAVA 11), running a JavaFX program on Raspberry Pi will not work.<br>
+   BellSoft provides the [Liberica JDK](https://bell-sw.com/pages/downloads/#/java-11-lts). The version dedicated for the Raspberry Pi includes JavaFX. And setting the version by default using the update-alternatives command.<br>
+   Thanks to [Frank Delporte](https://github.com/FDelporte), more info at [Java Magazine](https://blogs.oracle.com/javamagazine/getting-started-with-javafx-on-raspberry-pi)
+```text
+    $ cd /home/pi 
+    $ wget https://download.bell-sw.com/java/13/bellsoft-jdk13-linux-arm32-vfp-hflt.deb 
+    $ sudo apt-get install ./bellsoft-jdk13-linux-arm32-vfp-hflt.deb 
+    $ sudo update-alternatives --config javac 
+    $ sudo update-alternatives --config java
+```
 
 ### Running the (.jar) on a MAC
 
@@ -66,6 +78,13 @@ Sometimes opening the .jar normally won't work on MAC, instead you should launch
 ```text
     java -jar DrawingBotV3-X.X.X-XXXX-all.jar
 ```
+### Running the (.jar) on a Raspberry PI
+
+Opening the .jar may open it as an archive file, instead you should launch the jar from the terminal with the following command. Swapping in the correct file name
+```text
+    java -jar DrawingBotV3-X.X.X-XXXX-all.jar
+```
+
 
 
 


### PR DESCRIPTION
Added steps for Raspberry PI installation (Raspbian GNU/Linux 10 (buster)) to include JavaFX support. 
![image](https://user-images.githubusercontent.com/2389573/116900133-b0d7a280-ac38-11eb-8baa-a709028c0c61.png)
