### PR TITLE
Set AWTStroke end-cap style and join style to ROUND for export

### DIFF
--- a/src/main/java/drawingbot/javafx/observables/ObservableDrawingPen.java
+++ b/src/main/java/drawingbot/javafx/observables/ObservableDrawingPen.java
@@ -117,7 +117,7 @@ public class ObservableDrawingPen implements IDrawingPen, ICustomPen {
 
     public BasicStroke getAWTStroke(){
         if(awtStroke == null){
-            awtStroke = new BasicStroke(strokeSize.get());
+            awtStroke = new BasicStroke(strokeSize.get(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
         }
         return awtStroke;
     }


### PR DESCRIPTION
Hi Ollie,
The stroke end-cap and join style render changes made it to v1.1, but the export changes did not. This tweak works for me, for PDF & SVG export, but you might prefer to implement in a different way.
Thanks!