### PR TITLE
Scale PDF export to match paper size

### DIFF
--- a/src/main/java/drawingbot/DrawingBotV3.java
+++ b/src/main/java/drawingbot/DrawingBotV3.java
@@ -110,6 +110,7 @@ public class DrawingBotV3 {
 
     //VIEWPORT SETTINGS \\
     public static int SVG_DPI = 96;
+    public static int PDF_DPI = 72;
 
     public final SimpleBooleanProperty displayGrid = new SimpleBooleanProperty(false);
     public final SimpleDoubleProperty scaleMultiplier = new SimpleDoubleProperty(1.0F);


### PR DESCRIPTION
Hi Ollie,
This tweak adjusts the PDF export scale, so that PDF output page size matches input/selected paper size and PDF line weight matches pen width (e.g. 1 mm = 1 mm, vs 1 mm = 1 pt). Similar to SVG export scaling - which is already working as expected - but scaled to 72 DPI instead of 96.
Hope this is useful.
Thanks!