### PR TITLE
Add export resolution support for rescaled images/animations

### DIFF
--- a/src/main/java/drawingbot/files/exporters/AnimationExporter.java
+++ b/src/main/java/drawingbot/files/exporters/AnimationExporter.java
@@ -1,10 +1,12 @@
 package drawingbot.files.exporters;
 
+import drawingbot.DrawingBotV3;
 import drawingbot.files.ConfigFileHandler;
 import drawingbot.files.ExportTask;
 import drawingbot.files.FileUtils;
 import drawingbot.geom.basic.IGeometry;
 import drawingbot.plotting.PlottingTask;
+import drawingbot.utils.UnitsLength;
 import drawingbot.utils.VertexIterator;
 
 import javax.imageio.ImageIO;
@@ -21,11 +23,17 @@ public class AnimationExporter {
     public static DecimalFormat framePaddingFormat = new DecimalFormat("000000");
 
     public static void exportAnimation(ExportTask exportTask, PlottingTask plottingTask, Map<Integer, List<IGeometry>> geometries, String extension, File saveLocation) {
+        if (!exportTask.exportResolution.useOriginalSizing() && DrawingBotV3.INSTANCE.optimiseForPrint.get() && DrawingBotV3.INSTANCE.targetPenWidth.get() > 0){
+            int DPI = (int)ConfigFileHandler.getApplicationSettings().exportDPI;
+            int exportWidth = (int)Math.ceil((exportTask.exportResolution.printPageWidth / UnitsLength.INCHES.convertToMM) * DPI);
+            int exportHeight = (int)Math.ceil((exportTask.exportResolution.printPageHeight / UnitsLength.INCHES.convertToMM) * DPI);
+            exportTask.exportResolution.changePrintResolution(exportWidth, exportHeight);
+        }
         int width = (int)exportTask.exportResolution.getScaledWidth();
         int height = (int)exportTask.exportResolution.getScaledHeight();
 
-        BufferedImage image = ImageExporter.createFreshBufferedImage(exportTask);
-        Graphics2D graphics = ImageExporter.createFreshGraphics2D(exportTask, image);
+        BufferedImage image = ImageExporter.createFreshBufferedImage(exportTask, false);
+        Graphics2D graphics = ImageExporter.createFreshGraphics2D(exportTask, image, false);
         graphics.dispose(); //writes background colour to the image.
 
         int frameCount = 0;
@@ -58,6 +66,7 @@ public class AnimationExporter {
             exportTask.updateMessage("Frames: " + frameCount + " / " + totalFrameCount);
             exportTask.updateProgress(frameCount, totalFrameCount);
         }
+        exportTask.exportResolution.updatePrintScale();
     }
 
 }

--- a/src/main/java/drawingbot/files/presets/types/ConfigApplicationSettings.java
+++ b/src/main/java/drawingbot/files/presets/types/ConfigApplicationSettings.java
@@ -40,6 +40,9 @@ public class ConfigApplicationSettings implements IConfigData {
     public String pathToVPypeExecutable = "";
     public String vPypePresetName = "";
 
+    ////image settings
+    public float exportDPI = 300F;
+
     ////animation settings
     public float framesPerSecond = 25F;
     public int duration = 5;

--- a/src/main/java/drawingbot/image/PrintResolution.java
+++ b/src/main/java/drawingbot/image/PrintResolution.java
@@ -246,6 +246,8 @@ public class PrintResolution {
         scaledOffsetY = (imageOffsetY) + (getPrintOffsetY() / getPrintScale());
         scaledWidth = getPrintPageWidth() / getPrintScale();
         scaledHeight = getPrintPageHeight() / getPrintScale();
+        finalPrintScaleX = 1;
+        finalPrintScaleY = 1;
     }
 
     public boolean useOriginalSizing(){

--- a/src/main/java/drawingbot/javafx/FXExportController.java
+++ b/src/main/java/drawingbot/javafx/FXExportController.java
@@ -203,10 +203,13 @@ public class FXExportController {
     ////IMAGE SEQUENCE SETTINGS
     public AnchorPane anchorPaneImgSeqSettings = null;
 
+    public TextField textFieldDPI = null;
     public TextField textFieldFPS = null;
     public TextField textFieldDuration = null;
     public ChoiceBox<UnitsTime> choiceBoxTimeUnits = null;
 
+    
+    public Label labelExportSize = null;
     public Label labelFrameCount = null;
     public Label labelGeometriesPFrame = null;
     public Label labelVerticesPFrame = null;
@@ -214,6 +217,13 @@ public class FXExportController {
 
     public void initImageSequencePane(){
 
+        textFieldDPI.setTextFormatter(new TextFormatter<>(new FloatStringConverter(), 300F));
+        textFieldDPI.setText("" + ConfigFileHandler.getApplicationSettings().exportDPI);
+        textFieldDPI.textProperty().addListener((observable, oldValue, newValue) -> {
+            ConfigFileHandler.getApplicationSettings().exportDPI = Float.parseFloat(newValue);
+            updateImageSequenceStats();
+        });
+        
         textFieldFPS.setTextFormatter(new TextFormatter<>(new FloatStringConverter(), 25F));
         textFieldFPS.setText("" + ConfigFileHandler.getApplicationSettings().framesPerSecond);
         textFieldFPS.textProperty().addListener((observable, oldValue, newValue) -> {
@@ -251,7 +261,22 @@ public class FXExportController {
         if(verticesPerFrame == 1 && frameCount > verticesPerFrame){
             frameCount = (int)(DrawingBotV3.INSTANCE.getActiveTask() == null ? 0 : DrawingBotV3.INSTANCE.getActiveTask().plottedDrawing.getVertexCount());
         }
-
+        
+        if(DrawingBotV3.INSTANCE.openImage.get() != null){
+            if (!DrawingBotV3.INSTANCE.useOriginalSizing.get() && DrawingBotV3.INSTANCE.optimiseForPrint.get() && DrawingBotV3.INSTANCE.targetPenWidth.get() > 0){
+                int DPI = (int)ConfigFileHandler.getApplicationSettings().exportDPI;
+                int exportWidth = (int)Math.ceil((DrawingBotV3.INSTANCE.openImage.get().resolution.getPrintPageWidth() / UnitsLength.INCHES.convertToMM) * DPI);
+                int exportHeight = (int)Math.ceil((DrawingBotV3.INSTANCE.openImage.get().resolution.getPrintPageHeight() / UnitsLength.INCHES.convertToMM) * DPI);            
+                labelExportSize.setText(exportWidth + " x " + exportHeight);
+            }else{
+                int exportWidth = (int)DrawingBotV3.INSTANCE.openImage.get().resolution.getScaledWidth();
+                int exportHeight = (int)DrawingBotV3.INSTANCE.openImage.get().resolution.getScaledHeight();
+                labelExportSize.setText(exportWidth + " x " + exportHeight);
+            }
+        }else{
+            labelExportSize.setText("0 x 0");
+        }
+        
         labelFrameCount.setText("" + Utils.defaultNF.format(frameCount));
         labelGeometriesPFrame.setText("" + Utils.defaultNF.format(geometriesPerFrame));
         labelVerticesPFrame.setText("" + Utils.defaultNF.format(verticesPerFrame));

--- a/src/main/resources/fxml/exportsettings.fxml
+++ b/src/main/resources/fxml/exportsettings.fxml
@@ -414,7 +414,7 @@
                 </AnchorPane>
             </content>
           </Tab>
-           <Tab text="Image Sequences">
+           <Tab text="Image &amp; Animation">
               <content>
                  <AnchorPane fx:id="anchorPaneImgSeqSettings" minHeight="0.0" minWidth="0.0" prefHeight="315.0" prefWidth="400.0">
                     <children>
@@ -423,6 +423,22 @@
                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
                           </padding>
                           <children>
+                              <HBox prefHeight="100.0" prefWidth="200.0">
+                                 <children>
+                                    <Label contentDisplay="RIGHT" prefHeight="25.0" prefWidth="105.0" text="Export Resolution:" />
+                                    <TextField fx:id="textFieldDPI" prefHeight="25.0" prefWidth="56.0" />
+                                    <Label contentDisplay="RIGHT" prefHeight="25.0" prefWidth="40.0" text="PPI">
+                                       <padding>
+                                          <Insets left="5.0" />
+                                       </padding>
+                                    </Label>
+                                    <Label contentDisplay="RIGHT" prefHeight="25.0" prefWidth="190.0" text="Image Export Size: ">
+                                       <graphic>
+                                          <Label fx:id="labelExportSize" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="84.0" text="10000 x 10000" />
+                                       </graphic>
+                                    </Label>
+                                 </children>
+                              </HBox>
                               <Separator layoutX="18.0" layoutY="53.0" prefWidth="200.0" />
                               <HBox prefHeight="100.0" prefWidth="200.0">
                                  <children>


### PR DESCRIPTION
Hi Ollie,

Here is a proposed feature that allows rescaled images & animations to be exported at a predefined PPI, which can be set under Export Settings:

<img src="https://user-images.githubusercontent.com/1171023/144786925-a7e8cf45-2d77-4279-9a2e-af6294f3ec4b.png" width="400" height="400">

Basically a high-resolution export feature.
Let me know if there is anything here that you might want to do differently.

Thanks!

Hanz

PS. Took me a bit of time to get this working without breaking Thumbnails! ;p
