### PR TITLE
Add half pixel to scaled offset

### DIFF
--- a/src/main/java/drawingbot/image/PrintResolution.java
+++ b/src/main/java/drawingbot/image/PrintResolution.java
@@ -242,8 +242,8 @@ public class PrintResolution {
         print_scale_y = printDrawingHeight / (imageHeight * imageRenderScale);
         printScale = Math.min(print_scale_x, print_scale_y);
 
-        scaledOffsetX = (imageOffsetX)  + (getPrintOffsetX() / getPrintScale());
-        scaledOffsetY = (imageOffsetY) + (getPrintOffsetY() / getPrintScale());
+        scaledOffsetX = (imageOffsetX + 0.5)  + (getPrintOffsetX() / getPrintScale());
+        scaledOffsetY = (imageOffsetY + 0.5) + (getPrintOffsetY() / getPrintScale());
         scaledWidth = getPrintPageWidth() / getPrintScale();
         scaledHeight = getPrintPageHeight() / getPrintScale();
         finalPrintScaleX = 1;


### PR DESCRIPTION
Hi Ollie,
I believe that this is an appropriate tweak to correct the half-pixel offset between canvas and plotted geometry. 
The issue stems from the Java Graphics2D pixel numbering system, as described here:
https://math.hws.edu/graphicsbook/c2/s5.html
Let me know you have any concerns with this.
Hanz

Before:
![before](https://user-images.githubusercontent.com/1171023/147579533-12ce5feb-f0fb-46f6-bfd7-fa9f0443a137.jpg)
After:
![after](https://user-images.githubusercontent.com/1171023/147579544-104d5d3c-8f8f-44fb-8923-27af8ca49151.jpg)
