### PR TITLE
Add half-pixel offset to drawings only

### DIFF
--- a/src/main/java/drawingbot/DrawingBotV3.java
+++ b/src/main/java/drawingbot/DrawingBotV3.java
@@ -318,6 +318,7 @@ public class DrawingBotV3 {
     public PlottingTask initPlottingTask(PFMFactory<?> pfmFactory, ObservableDrawingSet drawingPenSet, BufferedImage image, File originalFile, EnumColourSplitter splitter){
         //only update the distribution type the first time the PFM is changed, also only trigger the update when Start Plotting is hit again, so the current drawing doesn't get re-rendered
         Platform.runLater(() -> {
+            display_mode.setValue(EnumDisplayMode.DRAWING);
             if(updateDistributionType != null && colourSplitter.get() == EnumColourSplitter.DEFAULT){
                 drawingPenSet.distributionType.set(updateDistributionType);
                 updateDistributionType = null;

--- a/src/main/java/drawingbot/image/PrintResolution.java
+++ b/src/main/java/drawingbot/image/PrintResolution.java
@@ -3,6 +3,7 @@ package drawingbot.image;
 import drawingbot.DrawingBotV3;
 import drawingbot.utils.EnumRotation;
 import drawingbot.utils.EnumScalingMode;
+import drawingbot.utils.EnumDisplayMode;
 
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
@@ -241,9 +242,15 @@ public class PrintResolution {
         print_scale_x = printDrawingWidth / (imageWidth * imageRenderScale);
         print_scale_y = printDrawingHeight / (imageHeight * imageRenderScale);
         printScale = Math.min(print_scale_x, print_scale_y);
-
-        scaledOffsetX = (imageOffsetX + 0.5)  + (getPrintOffsetX() / getPrintScale());
-        scaledOffsetY = (imageOffsetY + 0.5) + (getPrintOffsetY() / getPrintScale());
+        
+        //0.5 offset needed to align origin of drawing geometry with centre of pixel
+        if(DrawingBotV3.INSTANCE.display_mode.get() == EnumDisplayMode.DRAWING || DrawingBotV3.INSTANCE.display_mode.get() == EnumDisplayMode.SELECTED_PEN) {
+            scaledOffsetX = (imageOffsetX + 0.5)  + (getPrintOffsetX() / getPrintScale());
+            scaledOffsetY = (imageOffsetY + 0.5) + (getPrintOffsetY() / getPrintScale());
+        } else {
+            scaledOffsetX = (imageOffsetX)  + (getPrintOffsetX() / getPrintScale());
+            scaledOffsetY = (imageOffsetY) + (getPrintOffsetY() / getPrintScale());
+        }
         scaledWidth = getPrintPageWidth() / getPrintScale();
         scaledHeight = getPrintPageHeight() / getPrintScale();
         finalPrintScaleX = 1;


### PR DESCRIPTION
Hi Ollie,
This is a fix to apply the half-pixel offset to drawings only. Without this check, Reference and Lightened images are also rendered with the offset in the GUI.
Note that I had to set DisplayMode to DRAWING sooner (when the plot is initiated), rather than after the task stage is finished, so that `updatePrintScale()` sees the correct mode early enough. Perhaps the later call is now redundant..?
```    
public void onPlottingTaskStageFinished(PlottingTask task, EnumTaskStage stage){
        switch (stage){
            case QUEUED:
                break;
            case PRE_PROCESSING:
                Platform.runLater(() -> display_mode.setValue(EnumDisplayMode.DRAWING));
                break;
```