### PR TITLE
Pen redistribution tied to Displayed Shapes slider

### DIFF
--- a/src/main/java/drawingbot/javafx/FXController.java
+++ b/src/main/java/drawingbot/javafx/FXController.java
@@ -286,6 +286,7 @@ public class FXController {
                 int lines = (int)Utils.mapDouble(newValue.doubleValue(), 0, 1, 0, task.plottedDrawing.getGeometryCount());
                 task.plottedDrawing.displayedShapeMax.setValue(lines);
                 textFieldDisplayedShapesMax.setText(String.valueOf(lines));
+                task.plottedDrawing.updatePenDistribution();
                 DrawingBotV3.INSTANCE.reRender();
             }
         });
@@ -296,6 +297,7 @@ public class FXController {
                 int lines = (int)Utils.mapDouble(newValue.doubleValue(), 0, 1, 0, task.plottedDrawing.getGeometryCount());
                 task.plottedDrawing.displayedShapeMin.setValue(lines);
                 textFieldDisplayedShapesMin.setText(String.valueOf(lines));
+                task.plottedDrawing.updatePenDistribution();
                 DrawingBotV3.INSTANCE.reRender();
             }
         });
@@ -307,6 +309,7 @@ public class FXController {
                 task.plottedDrawing.displayedShapeMax.setValue(lines);
                 textFieldDisplayedShapesMax.setText(String.valueOf(lines));
                 rangeSliderDisplayedLines.setHighValue((double)lines / task.plottedDrawing.getGeometryCount());
+                task.plottedDrawing.updatePenDistribution();
                 DrawingBotV3.INSTANCE.reRender();
             }
         });
@@ -318,6 +321,7 @@ public class FXController {
                 task.plottedDrawing.displayedShapeMin.setValue(lines);
                 textFieldDisplayedShapesMin.setText(String.valueOf(lines));
                 rangeSliderDisplayedLines.setLowValue((double)lines / task.plottedDrawing.getGeometryCount());
+                task.plottedDrawing.updatePenDistribution();
                 DrawingBotV3.INSTANCE.reRender();
             }
         });

--- a/src/main/java/drawingbot/plotting/PlottedDrawing.java
+++ b/src/main/java/drawingbot/plotting/PlottedDrawing.java
@@ -1,5 +1,6 @@
 package drawingbot.plotting;
 
+import drawingbot.DrawingBotV3;
 import drawingbot.api.IGeometryFilter;
 import drawingbot.geom.basic.IGeometry;
 import drawingbot.javafx.observables.ObservableDrawingPen;
@@ -195,8 +196,19 @@ public class PlottedDrawing {
                     float percentage = (weighted ? (float)pen.distributionWeight.get() : 100) / totalWeight;
                     pen.currentPercentage.set(NumberFormat.getPercentInstance().format(percentage));
 
-                    //update geometry count
-                    int geometriesPerPen = (int)(percentage * getGeometryCount());
+                    //update geometry count                    
+                    int min = getDisplayedShapeMin();
+                    int max = getDisplayedShapeMax();
+                    int displayedGeometryCount = max - min;
+                    int geometriesPerPen;
+                    
+                    if (i == 0) {
+                        geometriesPerPen = (int)(percentage * displayedGeometryCount) + min;
+                    } else if (i == renderOrder.length - 1) {
+                        geometriesPerPen = (int)(percentage * displayedGeometryCount) + max - displayedGeometryCount;
+                    } else {
+                        geometriesPerPen = (int)(percentage * displayedGeometryCount);
+                    }
                     pen.currentGeometries.set(geometriesPerPen);
 
                     //set pen references


### PR DESCRIPTION
Hi Ollie,
This tweak ties pen redistribution to the Displayed Shapes slider.
Note that the pen redistribution will apply to exports whether the "Apply to export" checkbox is ticked or not, so this behaviour may need to be modified or made optional.
Any thoughts welcome.
Hanz