### PR TITLE
Set viewportScrollPane background colour to grey

### DIFF
--- a/src/main/java/drawingbot/javafx/FXController.java
+++ b/src/main/java/drawingbot/javafx/FXController.java
@@ -80,6 +80,7 @@ public class FXController {
             viewportScrollPane.setVvalue(0.5);
 
             viewportScrollPane.setOnMouseMoved(DrawingBotV3.INSTANCE::onMouseMoved);
+            viewportScrollPane.setStyle("-fx-background: gray;");
 
             initSeparateStages();
 


### PR DESCRIPTION
Hi Ollie,
This proposed UI tweak sets the drawing area background colour to middle grey. Useful for judging exposure levels, setting border widths, etc.
https://en.wikipedia.org/wiki/Gray_card
Hanz
![image](https://user-images.githubusercontent.com/1171023/152431361-83946713-979e-4564-b0aa-9ac6b8ec1f17.png)
