### PR TITLE
Set pen colour pick from image to primary button

### DIFF
--- a/src/main/java/drawingbot/javafx/FXController.java
+++ b/src/main/java/drawingbot/javafx/FXController.java
@@ -528,7 +528,7 @@ public class FXController {
     }
 
     public void onMousePressedColourPicker(MouseEvent event){
-        if(colourPickerActive && event.isSecondaryButtonDown()){
+        if(colourPickerActive && event.isPrimaryButtonDown()){
             doColourPick(event, false);
             event.consume();
         }


### PR DESCRIPTION
Hi Ollie,
Now that Pick Colour (from image) is a right-click option in the Pen Settings dialog, a left click probably makes more sense than a right click when picking a colour from the image.
Hanz