### PR TITLE
Fix for Drawing Area height/width limit of 999

### DIFF
--- a/src/main/java/drawingbot/javafx/FXController.java
+++ b/src/main/java/drawingbot/javafx/FXController.java
@@ -60,6 +60,7 @@ import org.controlsfx.glyphfont.Glyph;
 
 import java.awt.image.BufferedImageOp;
 import java.io.File;
+import java.text.DecimalFormat;
 import java.util.*;
 import java.util.logging.Level;
 
@@ -647,6 +648,7 @@ public class FXController {
 
 
         /////SIZING OPTIONS
+        final String drawingWidthHeightDecimalFormat = "####.###";
         checkBoxOriginalSizing.selectedProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.useOriginalSizing);
 
         paneDrawingAreaCustom.disableProperty().bind(checkBoxOriginalSizing.selectedProperty());
@@ -657,10 +659,10 @@ public class FXController {
         choiceBoxDrawingUnits.valueProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.inputUnits);
 
         textFieldDrawingWidth.textFormatterProperty().setValue(new TextFormatter<>(new FloatStringConverter(), 0F));
-        textFieldDrawingWidth.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaWidth, new NumberStringConverter());
+        textFieldDrawingWidth.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaWidth, new NumberStringConverter(new DecimalFormat(drawingWidthHeightDecimalFormat)));
 
         textFieldDrawingHeight.textFormatterProperty().setValue(new TextFormatter<>(new FloatStringConverter(), 0F));
-        textFieldDrawingHeight.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaHeight, new NumberStringConverter());
+        textFieldDrawingHeight.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaHeight, new NumberStringConverter(new DecimalFormat(drawingWidthHeightDecimalFormat)));
 
         buttonRotate.setOnAction(e -> {
             String width = textFieldDrawingWidth.getText();

--- a/src/main/java/drawingbot/javafx/FXController.java
+++ b/src/main/java/drawingbot/javafx/FXController.java
@@ -60,7 +60,6 @@ import org.controlsfx.glyphfont.Glyph;
 
 import java.awt.image.BufferedImageOp;
 import java.io.File;
-import java.text.DecimalFormat;
 import java.util.*;
 import java.util.logging.Level;
 
@@ -648,7 +647,6 @@ public class FXController {
 
 
         /////SIZING OPTIONS
-        final String drawingWidthHeightDecimalFormat = "####.###";
         checkBoxOriginalSizing.selectedProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.useOriginalSizing);
 
         paneDrawingAreaCustom.disableProperty().bind(checkBoxOriginalSizing.selectedProperty());
@@ -659,10 +657,10 @@ public class FXController {
         choiceBoxDrawingUnits.valueProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.inputUnits);
 
         textFieldDrawingWidth.textFormatterProperty().setValue(new TextFormatter<>(new FloatStringConverter(), 0F));
-        textFieldDrawingWidth.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaWidth, new NumberStringConverter(new DecimalFormat(drawingWidthHeightDecimalFormat)));
+        textFieldDrawingWidth.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaWidth, new NumberStringConverter(Utils.defaultDF));
 
         textFieldDrawingHeight.textFormatterProperty().setValue(new TextFormatter<>(new FloatStringConverter(), 0F));
-        textFieldDrawingHeight.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaHeight, new NumberStringConverter(new DecimalFormat(drawingWidthHeightDecimalFormat)));
+        textFieldDrawingHeight.textProperty().bindBidirectional(DrawingBotV3.INSTANCE.drawingArea.drawingAreaHeight, new NumberStringConverter(Utils.defaultDF));
 
         buttonRotate.setOnAction(e -> {
             String width = textFieldDrawingWidth.getText();

--- a/src/main/java/drawingbot/utils/Utils.java
+++ b/src/main/java/drawingbot/utils/Utils.java
@@ -1,5 +1,6 @@
 package drawingbot.utils;
 
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -10,6 +11,7 @@ public class Utils {
 
     public final static Random random = new Random();
     public final static NumberFormat defaultNF = NumberFormat.getNumberInstance();
+    public final static DecimalFormat defaultDF = new DecimalFormat("#.###");
     public final static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
 
     public static NumberFormat gCodeNF;


### PR DESCRIPTION
There was an issue with presets with a height or width > 999 not working. This fixes the issue and should enable larger format plots.

Fixes #48 