### PR TITLE
Use current import rather than export directory for importing files

### DIFF
--- a/src/main/java/drawingbot/javafx/FXHelper.java
+++ b/src/main/java/drawingbot/javafx/FXHelper.java
@@ -65,7 +65,7 @@ public class FXHelper {
         importFile((file, fileChooser) -> {
             FileUtils.updateImportDirectory(file.getParentFile());
             callback.accept(file, fileChooser);
-        }, FileUtils.getExportDirectory(), filters, title);
+        }, FileUtils.getImportDirectory(), filters, title);
     }
 
     public static void importFile(BiConsumer<File, FileChooser> callback, File initialDirectory, FileChooser.ExtensionFilter[] filters, String title){


### PR DESCRIPTION
When importing image files, the current _export_ directory is used as the starting directory. Small edit to use the current _import_ directory instead.