### PR TITLE
Fix for Line Sample rounding

### DIFF
--- a/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
+++ b/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
@@ -66,8 +66,8 @@ public class SimpleLineSampler {
             float deltaAngle = shading ? drawingDeltaAngle : drawingDeltaAngle / (float) maxTests;
             for (int d = 0; d < (shading ? 2 : maxTests); d ++) {
                 double angle = Math.toRadians((deltaAngle * d) + startAngle);
-                int x1 = (int)Math.round((Math.cos(angle)*maxLength) + startX);
-                int y1 = (int)Math.round((Math.sin(angle)*maxLength) + startY);
+                int x1 = (int)((Math.cos(angle)*maxLength) + startX);
+                int y1 = (int)((Math.sin(angle)*maxLength) + startY);
                 consumer.setPixel(x1, y1);
             }
         }

--- a/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
+++ b/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
@@ -66,8 +66,8 @@ public class SimpleLineSampler {
             float deltaAngle = shading ? drawingDeltaAngle : drawingDeltaAngle / (float) maxTests;
             for (int d = 0; d < (shading ? 2 : maxTests); d ++) {
                 double angle = Math.toRadians((deltaAngle * d) + startAngle);
-                int x1 = (int)Math.ceil((Math.cos(angle)*maxLength) + startX);
-                int y1 = (int)Math.ceil((Math.sin(angle)*maxLength) + startY);
+                int x1 = (int)Math.round((Math.cos(angle)*maxLength) + startX);
+                int y1 = (int)Math.round((Math.sin(angle)*maxLength) + startY);
                 consumer.setPixel(x1, y1);
             }
         }

--- a/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
+++ b/src/main/java/drawingbot/pfm/helpers/SimpleLineSampler.java
@@ -4,6 +4,8 @@ import drawingbot.api.IPixelData;
 import drawingbot.plotting.PlottingTools;
 
 import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 
 /**
  * A class which passes back options for the available lines given a point and parameters
@@ -64,11 +66,15 @@ public class SimpleLineSampler {
             tools.bresenham.plotCircle(startX, startY, maxLength, consumer);
         }else{
             float deltaAngle = shading ? drawingDeltaAngle : drawingDeltaAngle / (float) maxTests;
-            for (int d = 0; d < (shading ? 2 : maxTests); d ++) {
-                double angle = Math.toRadians((deltaAngle * d) + startAngle);
-                int x1 = (int)((Math.cos(angle)*maxLength) + startX);
-                int y1 = (int)((Math.sin(angle)*maxLength) + startY);
-                consumer.setPixel(x1, y1);
+            AffineTransform transform = new AffineTransform();
+            Point2D originalPoint = new Point2D.Double(startX, startY);
+            Point2D transformedPoint = new Point2D.Double();
+            for (int d = 0; d < (shading ? 2 : maxTests); d++) {
+                double angleDegrees = startAngle + (deltaAngle * d);
+                transform.setToRotation(Math.toRadians(angleDegrees), startX, startY);
+                transform.translate(maxLength, 0);
+                transform.transform(originalPoint, transformedPoint);
+                consumer.setPixel((int) transformedPoint.getX(), (int) transformedPoint.getY());
             }
         }
     }


### PR DESCRIPTION
Hi Ollie,

This is a fix for a "rounding error", which can be noticeable when lines should be exactly 0 or 90 degrees, but come out  slightly skewed. To test, in PFMSketchLines, set Start Angle Min and Start Angle Max to zero and Angle Tests to 4. All lines should be perpendicular, but some are slightly off.
Replacing Math.ceil() with Math.round()fixes this. Another option would be to let the cast to (int) floor the angle instead...

/Hanz